### PR TITLE
[implant] Fix colliding short options (#58)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,8 @@ const PREFIX_LOG_NAME: &str = "openbas-implant.log";
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    #[arg(short, long)]
+    // short: d for destination
+    #[arg(short = 'd', long)]
     uri: String,
     #[arg(short, long)]
     token: String,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Set explicit short option for colliding argument

Fixes #58 

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Argument names beginning with the same first character were creating a collision in the short options which default to the first character of the long option name, here `uri` and `unsecured_certificate`. I propose `d` (destination) as the replacement short option for uri.

```
antoinemzs@filibook:~/filigran/implant$ ./target/debug/openbas-implant --help
Usage: openbas-implant --uri <URI> --token <TOKEN> --unsecured-certificate <UNSECURED_CERTIFICATE> --with-proxy <WITH_PROXY> --agent-id <AGENT_ID> --inject-id <INJECT_ID>

Options:
  -d, --uri <URI>                                      
  -t, --token <TOKEN>                                  
  -u, --unsecured-certificate <UNSECURED_CERTIFICATE>  
  -w, --with-proxy <WITH_PROXY>                        
  -a, --agent-id <AGENT_ID>                            
  -i, --inject-id <INJECT_ID>                          
  -h, --help                                           Print help
  -V, --version                                        Print version
```