### PR TITLE
[implant] feat(execution) : prevent too big execution traces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,8 @@ jobs:
       - run: $env:PATH = "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\ARM64\bin;" + $env:PATH; Invoke-Expression '& "$env:USERPROFILE\.cargo\bin\cargo" clippy -- -D warnings'
       - run: $env:PATH = "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\ARM64\bin;" + $env:PATH; Invoke-Expression '& "$env:USERPROFILE\.cargo\bin\cargo" fmt -- --check'
       - run: git config --global --unset url.ssh://git@github.com.insteadOf
-      - run: cargo audit
+      - run: if (Test-Path $env:USERPROFILE\.cargo\advisory-db\) {rm -r -Force $env:USERPROFILE\.cargo\advisory-db\} git clone https://github.com/rustsec/advisory-db $env:USERPROFILE\.cargo\advisory-db
+      - run: cargo audit --no-fetch
       - run: git config --global url.ssh://git@github.com.insteadOf https://github.com/
       - run: $env:PATH = "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\ARM64\bin;" + $env:PATH; Invoke-Expression '& "$env:USERPROFILE\.cargo\bin\cargo" build --release'
       - run: $env:PATH = "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\ARM64\bin;" + $env:PATH; Invoke-Expression '& "$env:USERPROFILE\.cargo\bin\cargo" test --release'

--- a/src/handle/handle_command.rs
+++ b/src/handle/handle_command.rs
@@ -7,6 +7,7 @@ use log::info;
 use crate::api::manage_inject::InjectorContractPayload;
 use crate::api::Client;
 use crate::handle::handle_execution::handle_execution_result;
+use crate::handle::ExecutionParam;
 use crate::process::command_exec::command_execution;
 
 fn compute_working_dir() -> PathBuf {
@@ -29,19 +30,17 @@ pub fn compute_command(command: &str) -> String {
 }
 
 pub fn handle_execution_command(
-    semantic: &str,
+    params: &ExecutionParam,
     api: &Client,
-    inject_id: String,
-    agent_id: String,
     command: &str,
     executor: &str,
     pre_check: bool,
 ) -> i32 {
     let now = Instant::now();
-    info!("{semantic} execution: {command:?}");
+    info!("{} execution: {command:?}", params.semantic);
     let command_result = command_execution(command, executor, pre_check);
     let elapsed = now.elapsed().as_millis();
-    handle_execution_result(semantic, api, inject_id, agent_id, command_result, elapsed)
+    handle_execution_result(params, api, command_result, elapsed)
 }
 
 pub fn handle_command(
@@ -49,14 +48,18 @@ pub fn handle_command(
     agent_id: String,
     api: &Client,
     contract_payload: &InjectorContractPayload,
+    max_size: usize,
 ) {
     let command = contract_payload.command_content.clone().unwrap();
     let executor = contract_payload.command_executor.clone().unwrap();
     let _ = handle_execution_command(
-        "command_execution",
+        &ExecutionParam {
+            semantic: String::from("command_execution"),
+            inject_id: inject_id.clone(),
+            agent_id: agent_id.clone(),
+            max_size,
+        },
         api,
-        inject_id.clone(),
-        agent_id.clone(),
         &command,
         &executor,
         false,

--- a/src/handle/handle_execution.rs
+++ b/src/handle/handle_execution.rs
@@ -3,40 +3,79 @@ use log::info;
 use crate::api::manage_inject::UpdateInput;
 use crate::api::Client;
 use crate::common::error_model::Error;
-use crate::handle::ExecutionOutput;
+use crate::handle::{ExecutionOutput, ExecutionParam};
 use crate::process::command_exec::ExecutionResult;
 
+const PREVIEW_LOGS_SIZE: usize = 100000;
+
 pub fn handle_execution_result(
-    semantic: &str,
+    params: &ExecutionParam,
     api: &Client,
-    inject_id: String,
-    agent_id: String,
     command_result: Result<ExecutionResult, Error>,
     elapsed: u128,
 ) -> i32 {
     match command_result {
         Ok(res) => {
-            info!("{} execution stdout: {:?}", semantic, res.stdout);
-            info!("{} execution stderr: {:?}", semantic, res.stderr);
             let stdout = res.stdout;
             let stderr = res.stderr;
             let exit_code = res.exit_code;
             let message = ExecutionOutput {
-                stdout,
-                stderr,
+                stdout: stdout.clone(),
+                stderr: stderr.clone(),
                 exit_code,
             };
             let execution_message = serde_json::to_string(&message).unwrap();
-            let _ = api.update_status(
-                inject_id,
-                agent_id,
-                UpdateInput {
-                    execution_message,
-                    execution_status: res.status,
-                    execution_duration: elapsed,
-                    execution_action: String::from(semantic),
-                },
-            );
+            let size_of_message = execution_message.len();
+            // If the execution traces are too big
+            if size_of_message > params.max_size {
+                // We add a truncated version in the logs
+                let mut truncated_stdout = stdout.clone();
+                let mut truncated_stderr = stderr.clone();
+                truncated_stdout.truncate(PREVIEW_LOGS_SIZE);
+                truncated_stderr.truncate(PREVIEW_LOGS_SIZE);
+                info!(
+                    "{} execution stdout: {:?}",
+                    params.semantic,
+                    truncated_stdout.clone()
+                );
+                info!(
+                    "{} execution stderr: {:?}",
+                    params.semantic,
+                    truncated_stderr.clone()
+                );
+
+                // And we set the inject into an ERROR status with some traces
+                let error_message = ExecutionOutput {
+                    stdout: truncated_stdout,
+                    stderr: truncated_stderr,
+                    exit_code,
+                };
+                let mut info_message = format!("The generated logs are above the maximum size of {} characters. This is unprocessable by OpenAEV. Here are the beginning of the logs :\n", params.max_size);
+                info_message.push_str(serde_json::to_string(&error_message).unwrap().as_str());
+                let _ = api.update_status(
+                    params.inject_id.clone(),
+                    params.agent_id.clone(),
+                    UpdateInput {
+                        execution_message: info_message,
+                        execution_status: String::from("ERROR"),
+                        execution_duration: elapsed,
+                        execution_action: String::from(params.semantic.as_str()),
+                    },
+                );
+            } else {
+                info!("{} execution stdout: {:?}", params.semantic, stdout.clone());
+                info!("{} execution stderr: {:?}", params.semantic, stderr.clone());
+                let _ = api.update_status(
+                    params.inject_id.clone(),
+                    params.agent_id.clone(),
+                    UpdateInput {
+                        execution_message,
+                        execution_status: res.status,
+                        execution_duration: elapsed,
+                        execution_action: params.semantic.clone(),
+                    },
+                );
+            }
             // Return execution code
             res.exit_code
         }
@@ -51,13 +90,13 @@ pub fn handle_execution_result(
             };
             let execution_message = serde_json::to_string(&message).unwrap();
             let _ = api.update_status(
-                inject_id,
-                agent_id,
+                params.inject_id.clone(),
+                params.agent_id.clone(),
                 UpdateInput {
                     execution_message,
                     execution_status: String::from("ERROR"),
                     execution_duration: elapsed,
-                    execution_action: String::from(semantic),
+                    execution_action: params.semantic.clone(),
                 },
             );
             // Return error code

--- a/src/handle/handle_file.rs
+++ b/src/handle/handle_file.rs
@@ -6,6 +6,7 @@ use crate::api::manage_reporting::{report_error, report_success};
 use crate::api::Client;
 use crate::common::error_model::Error;
 use crate::handle::handle_execution::handle_execution_result;
+use crate::handle::ExecutionParam;
 use crate::process::file_exec::file_execution;
 
 pub fn handle_execution_file(
@@ -14,12 +15,23 @@ pub fn handle_execution_file(
     inject_id: String,
     agent_id: String,
     filename: &String,
+    max_size: usize,
 ) -> i32 {
     let now = Instant::now();
     info!("{semantic} execution: {filename:?}");
     let command_result = file_execution(filename.as_str());
     let elapsed = now.elapsed().as_millis();
-    handle_execution_result(semantic, api, inject_id, agent_id, command_result, elapsed)
+    handle_execution_result(
+        &ExecutionParam {
+            semantic: semantic.to_owned(),
+            inject_id,
+            agent_id,
+            max_size,
+        },
+        api,
+        command_result,
+        elapsed,
+    )
 }
 
 pub fn handle_file(

--- a/src/handle/handle_file_execute.rs
+++ b/src/handle/handle_file_execute.rs
@@ -7,6 +7,7 @@ pub fn handle_file_execute(
     agent_id: String,
     api: &Client,
     contract_payload: &InjectorContractPayload,
+    max_size: usize,
 ) {
     let InjectorContractPayload {
         executable_file, ..
@@ -26,6 +27,7 @@ pub fn handle_file_execute(
                 inject_id.clone(),
                 agent_id.clone(),
                 &filename,
+                max_size,
             );
         }
         Err(_) => {

--- a/src/handle/mod.rs
+++ b/src/handle/mod.rs
@@ -13,3 +13,10 @@ pub struct ExecutionOutput {
     pub stderr: String,
     pub exit_code: i32,
 }
+
+pub struct ExecutionParam {
+    pub semantic: String,
+    pub inject_id: String,
+    pub agent_id: String,
+    pub max_size: usize,
+}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add a safeguard for when execution logs are too big
*

### Testing Instructions

1. Use a custom payload that generates a lot of logs like gci -Recurse
2. Check that it ends up in ERROR with the correct error message
3. Try again with a smaller payload and make sure it still works as usual

### Related issues

* OpenAEV-Platform/implant#4779
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
