### PR TITLE
[implant] feat(stix): delete file after download on drop files (#3511)

### DIFF
--- a/src/handle/handle_file.rs
+++ b/src/handle/handle_file.rs
@@ -7,7 +7,7 @@ use crate::api::Client;
 use crate::common::error_model::Error;
 use crate::handle::handle_execution::handle_execution_result;
 use crate::handle::ExecutionParam;
-use crate::process::file_exec::file_execution;
+use crate::process::file_exec::{delete_file, file_execution};
 
 pub fn handle_execution_file(
     semantic: &str,
@@ -71,6 +71,7 @@ pub fn handle_file(
                         None,
                         elapsed,
                     );
+                    delete_file(&filename)?;
                     Ok(filename)
                 }
                 Err(err) => {


### PR DESCRIPTION
### Proposed changes

* Delete dropped file after download on FileDrop Payloads executions

### Testing Instructions

1. Run the implant with a FileDrop Inject
2. Dropped file should be deleted after execution
You can check in debug, before execution of delete_file method into handle_file.rs file, the dropped file should be into payload folder, after releasing debug, dropped file should be deleted
