### PR TITLE
[implant] chore(deps): force rustls-webpki@">0.103.9"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -67,7 +67,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -213,7 +213,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -798,7 +798,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -830,7 +830,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openaev-implant"
-version = "2.3.0"
+version = "2.3.2"
 dependencies = [
  "base64",
  "clap",
@@ -840,6 +840,7 @@ dependencies = [
  "percent-encoding",
  "reqwest",
  "rolling-file",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "tracing-appender",
@@ -1177,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rolling-file = "0.2.0"
 clap = { version = "4.5.7", features = ["derive"] }
 mailparse = "0.16.0"
 percent-encoding ="2.3.2"
+rustls-webpki = ">0.103.9"
 
 [dev-dependencies]
 mockito = "1.7.0"


### PR DESCRIPTION
force rustls-webpki@">0.103.9"

Fixing:
>antoinemzs@filibook:~/filigran/implant$ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 1017 security advisories (from /home/antoinemzs/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (223 crate dependencies)
Crate:     rustls-webpki
Version:   0.103.9
Title:     CRLs not considered authoritative by Distribution Point due to faulty matching logic
Date:      2026-03-20
ID:        RUSTSEC-2026-0049
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0049
Solution:  Upgrade to >=0.103.10
Dependency tree:
rustls-webpki 0.103.9
└── rustls 0.23.36
    ├── tokio-rustls 0.26.4
    │   ├── reqwest 0.12.28
    │   │   └── openaev-implant 2.3.2
    │   └── hyper-rustls 0.27.7
    │       └── reqwest 0.12.28
    ├── reqwest 0.12.28
    ├── quinn-proto 0.11.14
    │   └── quinn 0.11.9
    │       └── reqwest 0.12.28
    ├── quinn 0.11.9
    └── hyper-rustls 0.27.7
>
>error: 1 vulnerability found!
