### PR TITLE
fix(security): sanitize HTTP response and token logging (#5877)

### DIFF
--- a/src/api/manage_inject.rs
+++ b/src/api/manage_inject.rs
@@ -29,6 +29,18 @@ where
     io::copy(&mut content.as_slice(), &mut writer)
 }
 
+/// Log-safe summary of an HTTP response (status only, no headers)
+fn safe_response_summary(response: &Response) -> String {
+    format!(
+        "HTTP {} {}",
+        response.status().as_u16(),
+        response
+            .status()
+            .canonical_reason()
+            .unwrap_or("Unknown"),
+    )
+}
+
 #[derive(Debug, Deserialize)]
 pub struct PayloadArg {
     pub r#type: String,
@@ -152,7 +164,12 @@ impl Client {
         retry: u64,
     ) -> Result<UpdateInjectResponse, Error> {
         if response.status().is_success() {
-            info!("response {response:?} to update status for inject id: {inject_id:?} and agent id: {agent_id:?}");
+            info!(
+                "{} — update status for inject_id={:?}, agent_id={:?}",
+                safe_response_summary(&response),
+                inject_id,
+                agent_id
+            );
             response
                 .json::<UpdateInjectResponse>()
                 .map_err(|e| Error::Internal(e.to_string()))

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -6,11 +6,19 @@ pub mod manage_reporting;
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const AUTHORIZATION_HEADER: &str = "Authorization";
 
-#[derive(Debug)]
 pub struct Client {
     http_client: reqwest::blocking::Client,
     server_url: String,
     token: String,
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("server_url", &self.server_url)
+            .field("token", &"[REDACTED]")
+            .finish()
+    }
 }
 
 impl Client {


### PR DESCRIPTION
## 🔒 Security Fix — Prevent credential leaks in logs

Closes #5877

### Problem

In `manage_inject.rs`, the `update_status_response` method logs the full `reqwest::Response` object using `{response:?}`. The `Debug` format of `reqwest::blocking::Response` dumps **all HTTP headers**, including:
- `set-cookie: JSESSIONID=...` — session cookies from the Spring Boot server
- Any other sensitive headers in the response

These logs are written to `openaev-implant.log` on disk (JSON format, daily rotation, 3-file retention), creating a **credential exposure risk** on the agent host.

Additionally, the `Client` struct derives `Debug` which would expose the Bearer token if ever debug-printed.

### Changes

| File | Change | Impact |
|---|---|---|
| `src/api/manage_inject.rs` | Replace `{response:?}` with `safe_response_summary()` that only logs HTTP status code | 🔴 **Main fix** — eliminates header leak |
| `src/api/manage_inject.rs` | Add `safe_response_summary()` helper function | Defense in depth — reusable safe logging |
| `src/api/mod.rs` | Replace `#[derive(Debug)]` on `Client` with custom `Debug` impl that redacts `token` | 🟡 **Preventive** — masks Bearer token in any future debug output |

### Before / After

**Before** (leaks JSESSIONID + all headers):
```
INFO response Response { url: "https://...", status: 200, headers: {"set-cookie": "JSESSIONID=ABC123..."} } to update status for inject id: "..." and agent id: "..."
```

**After** (safe, status only):
```
INFO HTTP 200 OK — update status for inject_id="...", agent_id="..."
```

### Risk Assessment

- **Blast radius**: Low — only logging changes, zero business logic impact
- **Backward compatibility**: Full — log format is not a public API
- **Testing**: Existing tests unaffected (no assertions on log format)