### PR TITLE
chore: audit & align issue templates (#140)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,1 @@
 blank_issues_enabled: true
-contact_links:
-  - name: Report a security vulnerability
-    url: https://github.com/OpenAEV-Platform/implant/security/policy
-    about: Please review our security policy and report vulnerabilities privately and responsibly.
-  - name: Filigran community Slack
-    url: https://community.filigran.io
-    about: Ask questions and chat with the Filigran community.


### PR DESCRIPTION
## Summary

Audits and aligns the GitHub issue templates in `.github/ISSUE_TEMPLATE/` for the OpenAEV implant:

- `bug_report.md`, `feature_request.md`, `question.md` — already aligned (verified)
- `config.yml` — stripped to the public default (`blank_issues_enabled: true`)

Removed the security `contact_link` (this is a public repo with native private vulnerability reporting, so the link duplicates the built-in report button) and the `Filigran community Slack` link. No `documentation.yaml` (this repo does not ship docs).

Closes #140