### PR TITLE
fix(implant): changed embedding of vcc dlls in artefacts (#165)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,3 +2,15 @@
 lint = "clippy -- -D warnings"
 fmtfix = "fmt"
 fmtcheck = "fmt -- --check"
+
+# Force static CRT linkage on all Windows MSVC targets.
+# This embeds the Visual C++ runtime into the binary so it runs on
+# machines without the VC++ Redistributable installed.
+#
+# NOTE: Do NOT set RUSTFLAGS in CI — it would override these
+# target-specific rustflags and silently drop +crt-static.
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/implant-ci.yml
+++ b/.github/workflows/implant-ci.yml
@@ -298,13 +298,32 @@ jobs:
 
       - name: Build (release)
         run: |
-          RUSTFLAGS="-C strip=symbols"
-          if [[ "${{ matrix.os }}" == "windows" ]]; then
-            RUSTFLAGS="$RUSTFLAGS -C target-feature=+crt-static"
-          fi
-          export RUSTFLAGS
+          # Static CRT linkage for Windows is configured in .cargo/config.toml
+          # (target-feature=+crt-static) so VCRUNTIME140.dll is not required at
+          # runtime.
+          #
+          # IMPORTANT: We must NOT set RUSTFLAGS here because it would *override*
+          # (not combine with) the target-specific rustflags in .cargo/config.toml,
+          # effectively dropping +crt-static.  This was the root cause of the
+          # VCRUNTIME140.dll missing error on Windows ARM64.
           cargo build --target=${{ matrix.target }} --release --locked
         shell: bash
+
+      - name: Verify no dynamic CRT dependency (Windows)
+        if: matrix.os == 'windows'
+        shell: bash
+        run: |
+          BIN="./target/${{ matrix.target }}/release/openaev-implant.exe"
+          echo "Checking $BIN for VCRUNTIME imports…"
+          # rustup includes llvm-objdump; use it instead of dumpbin which
+          # may not be on PATH (especially on windows-11-arm runners).
+          if rustup run stable llvm-objdump --private-headers "$BIN" \
+             | grep -qi "vcruntime"; then
+            echo "::error::Binary still dynamically links to VCRUNTIME:"
+            rustup run stable llvm-objdump --private-headers "$BIN" | grep -i "vcruntime"
+            exit 1
+          fi
+          echo "✅ No VCRUNTIME dependency found — static CRT linkage confirmed."
 
       - name: Install cargo cache
         run: |


### PR DESCRIPTION
### Proposed changes

* Moved rustflag building (including the +crt-static flag) from the github action to the cargo config so that any compile command will use it and embed the required libraries

### Testing Instructions

1. Build implant on a windows Arm64 machine
2. Execute it on a windows Arm64 machine that doesn't have the VCC preinstalled

### Related issues

* Related to https://github.com/OpenAEV-Platform/agent/issues/165

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...-->
