### PR TITLE
ci: add Codecov coverage reporting (#96)

### DIFF
--- a/.github/workflows/implant-ci.yml
+++ b/.github/workflows/implant-ci.yml
@@ -14,6 +14,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   # ──────────────────────────────────────────────────────────────────
@@ -222,7 +223,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           files: lcov.info
           flags: implant
           disable_search: true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![CircleCI](https://circleci.com/gh/OpenAEV-Platform/implant.svg?style=shield)](https://circleci.com/gh/OpenAEV-Platform/implant/tree/main)
 [![GitHub release](https://img.shields.io/github/release/OpenAEV-Platform/implant.svg)](https://github.com/OpenAEV-Platform/implant/releases/latest)
 [![Slack Status](https://img.shields.io/badge/slack-3K%2B%20members-4A154B)](https://community.filigran.io)
+[![codecov](https://codecov.io/gh/OpenAEV-Platform/implant/graph/badge.svg)](https://codecov.io/gh/OpenAEV-Platform/implant)
 
 The following repository is used to store the OpenAEV implant for the platform. For performance and low level access, the agent is written in Rust. Please start your journey with https://doc.rust-lang.org/book.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,28 @@
+codecov:
+  notify:
+    after_n_builds: 1
+
+coverage:
+  status:
+    project:
+      implant:
+        target: auto
+        informational: true
+        flags:
+          - implant
+    patch:
+      implant:
+        target: 80%
+        informational: true
+        flags:
+          - implant
+
+flags:
+  implant:
+    paths:
+      - src/
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: true


### PR DESCRIPTION
## Summary

- Switch Codecov upload from `CODECOV_TOKEN` secret to GitHub OIDC authentication
- Add `codecov.yml` with project/patch coverage status checks, `implant` flag with path filter, and PR comment configuration — aligned with the openaev platform config
- Add Codecov badge to `README.md`

Closes #96