### PR TITLE
fix(ci): switch Codecov upload from OIDC to token authentication (#96)

### DIFF
--- a/.github/workflows/implant-ci.yml
+++ b/.github/workflows/implant-ci.yml
@@ -14,7 +14,6 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   # ──────────────────────────────────────────────────────────────────
@@ -223,7 +222,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:
-          use_oidc: true
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           flags: implant
           disable_search: true


### PR DESCRIPTION
## Summary

- Replace `use_oidc: true` with `token: ${{ secrets.CODECOV_TOKEN }}` in the coverage upload step
- Remove `id-token: write` permission (no longer needed)

OIDC authentication is not configured on the Codecov organization. This switches to token-based authentication, aligned with how openaev handles Codecov uploads.

**Prerequisite:** the `CODECOV_TOKEN` secret must be set at the org or repo level.