### PR TITLE
feat: decrypt encrypted malware samples before detonation (#163)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,23 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +88,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +129,15 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -145,7 +180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -170,6 +205,16 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -228,6 +273,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,11 +296,29 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -268,6 +337,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +357,28 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "displaydoc"
@@ -310,6 +411,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -376,6 +487,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,9 +516,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -444,6 +567,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -690,6 +822,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +914,16 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -863,6 +1014,7 @@ dependencies = [
  "serde_json",
  "tracing-appender",
  "tracing-subscriber",
+ "zip",
 ]
 
 [[package]]
@@ -892,6 +1044,16 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
 ]
 
 [[package]]
@@ -1338,6 +1500,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,6 +1524,12 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "similar"
@@ -1691,6 +1870,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,6 +1916,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -2062,6 +2253,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zerotrie"
@@ -2097,7 +2302,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror",
+ "zeroize",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ rolling-file = "0.2.0"
 mailparse = "0.16.0"
 percent-encoding = "2.3.2"
 rustls-webpki = ">0.103.12"
+zip = { version = "2.2.0", default-features = false, features = ["aes-crypto", "deflate"] }
 
 [dependencies.reqwest]
 version = "0.12.28"

--- a/src/api/manage_inject.rs
+++ b/src/api/manage_inject.rs
@@ -56,6 +56,9 @@ pub struct InjectorContractPayload {
     pub executable_file: Option<String>,
     // DnsResolution
     pub dns_resolution_hostname: Option<String>,
+    // Clear zip password for an encrypted malware sample; when present the downloaded file is a
+    // password-protected zip that must be decrypted in memory before it is dropped/executed.
+    pub payload_sample_zip_password: Option<String>,
     // Prerequisites
     pub payload_prerequisites: Option<Vec<PayloadPrerequisite>>,
     // Command
@@ -180,14 +183,28 @@ impl Client {
         tenant_id: String,
         in_memory: bool,
     ) -> Result<String, Error> {
+        self.download_file_maybe_encrypted(document_id, tenant_id, in_memory, &None)
+    }
+
+    /// Download a file by id. When `sample_zip_password` is set, the downloaded object is a
+    /// password-protected zip (a malware sample): it is buffered and decrypted in memory, and the
+    /// single contained entry is written out as the working file, just before detonation.
+    pub fn download_file_maybe_encrypted(
+        &self,
+        document_id: &String,
+        tenant_id: String,
+        in_memory: bool,
+        sample_zip_password: &Option<String>,
+    ) -> Result<String, Error> {
         match self
-            .get(&format!(
-                "/api/tenants/{tenant_id}/documents/{document_id}/file"
-            ))
+            .get(&format!("/api/tenants/{tenant_id}/files/{document_id}/file"))
             .send()
         {
             Ok(response) => {
                 if response.status().is_success() {
+                    if let Some(password) = sample_zip_password {
+                        return decrypt_sample_to_disk(response, password);
+                    }
                     let name = extract_filename(&response)?;
                     let decoded_name = decode_filename(&name)?;
                     let output_path = get_output_path(&decoded_name)?;
@@ -214,6 +231,37 @@ impl Client {
                 }
             }
             Err(err) => Err(Error::Internal(err.to_string())),
+        }
+    }
+}
+
+/// Read the encrypted-zip response fully, decrypt its single entry with the given password, and
+/// write the plaintext sample to the working payloads directory. Returns the extracted file name.
+fn decrypt_sample_to_disk(
+    response: Response,
+    password: &str,
+) -> Result<String, Error> {
+    let bytes = response
+        .bytes()
+        .map_err(|e| Error::Internal(e.to_string()))?
+        .to_vec();
+    let reader = std::io::Cursor::new(bytes);
+    let mut archive =
+        zip::ZipArchive::new(reader).map_err(|e| Error::Internal(e.to_string()))?;
+    let mut entry = archive
+        .by_index_decrypt(0, password.as_bytes())
+        .map_err(|e| Error::Internal(e.to_string()))?;
+    let entry_name = entry
+        .enclosed_name()
+        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
+        .unwrap_or_else(|| "sample".to_string());
+    let output_path = get_output_path(&entry_name)?;
+    let mut output_file = File::create(output_path.clone())?;
+    match io::copy(&mut entry, &mut output_file) {
+        Ok(_) => Ok(entry_name),
+        Err(err) => {
+            let _ = fs::remove_file(output_path);
+            Err(Error::Io(err))
         }
     }
 }

--- a/src/api/manage_inject.rs
+++ b/src/api/manage_inject.rs
@@ -197,7 +197,9 @@ impl Client {
         sample_zip_password: &Option<String>,
     ) -> Result<String, Error> {
         match self
-            .get(&format!("/api/tenants/{tenant_id}/files/{document_id}/file"))
+            .get(&format!(
+                "/api/tenants/{tenant_id}/files/{document_id}/file"
+            ))
             .send()
         {
             Ok(response) => {
@@ -237,20 +239,29 @@ impl Client {
 
 /// Read the encrypted-zip response fully, decrypt its single entry with the given password, and
 /// write the plaintext sample to the working payloads directory. Returns the extracted file name.
-fn decrypt_sample_to_disk(
-    response: Response,
-    password: &str,
-) -> Result<String, Error> {
+fn decrypt_sample_to_disk(response: Response, password: &str) -> Result<String, Error> {
     let bytes = response
         .bytes()
         .map_err(|e| Error::Internal(e.to_string()))?
         .to_vec();
     let reader = std::io::Cursor::new(bytes);
-    let mut archive =
-        zip::ZipArchive::new(reader).map_err(|e| Error::Internal(e.to_string()))?;
+    let mut archive = zip::ZipArchive::new(reader).map_err(|e| Error::Internal(e.to_string()))?;
+    // The Files feature ships one sample per encrypted zip; reject anything else so we never
+    // silently detonate the wrong entry.
+    if archive.len() != 1 {
+        return Err(Error::Internal(format!(
+            "Encrypted sample archive must contain exactly one entry, found {}",
+            archive.len()
+        )));
+    }
     let mut entry = archive
         .by_index_decrypt(0, password.as_bytes())
         .map_err(|e| Error::Internal(e.to_string()))?;
+    if entry.is_dir() {
+        return Err(Error::Internal(
+            "Encrypted sample archive entry is a directory, expected a file".to_string(),
+        ));
+    }
     let entry_name = entry
         .enclosed_name()
         .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))

--- a/src/handle/handle_file.rs
+++ b/src/handle/handle_file.rs
@@ -43,6 +43,7 @@ pub fn handle_file(
     api: &Client,
     file_target: &Option<String>,
     in_memory: bool,
+    sample_zip_password: &Option<String>,
 ) -> Result<String, Error> {
     match file_target {
         None => {
@@ -64,7 +65,12 @@ pub fn handle_file(
         }
         Some(document_id) => {
             let now = Instant::now();
-            let download = api.download_file(document_id, tenant_id.clone(), in_memory);
+            let download = api.download_file_maybe_encrypted(
+                document_id,
+                tenant_id.clone(),
+                in_memory,
+                sample_zip_password,
+            );
             let elapsed = now.elapsed().as_millis();
             match download {
                 Ok(filename) => {

--- a/src/handle/handle_file_drop.rs
+++ b/src/handle/handle_file_drop.rs
@@ -9,6 +9,18 @@ pub fn handle_file_drop(
     api: &Client,
     contract_payload: &InjectorContractPayload,
 ) {
-    let InjectorContractPayload { file_drop_file, .. } = contract_payload;
-    let _ = handle_file(inject_id, agent_id, tenant_id, api, file_drop_file, false);
+    let InjectorContractPayload {
+        file_drop_file,
+        payload_sample_zip_password,
+        ..
+    } = contract_payload;
+    let _ = handle_file(
+        inject_id,
+        agent_id,
+        tenant_id,
+        api,
+        file_drop_file,
+        false,
+        payload_sample_zip_password,
+    );
 }

--- a/src/handle/handle_file_execute.rs
+++ b/src/handle/handle_file_execute.rs
@@ -11,7 +11,9 @@ pub fn handle_file_execute(
     max_size: usize,
 ) {
     let InjectorContractPayload {
-        executable_file, ..
+        executable_file,
+        payload_sample_zip_password,
+        ..
     } = contract_payload;
     let handle_file = handle_file(
         inject_id.clone(),
@@ -20,6 +22,7 @@ pub fn handle_file_execute(
         api,
         executable_file,
         false,
+        payload_sample_zip_password,
     );
     match handle_file {
         Ok(filename) => {

--- a/src/tests/api/manage_inject.rs
+++ b/src/tests/api/manage_inject.rs
@@ -17,7 +17,7 @@ mod tests {
         let content_disposition = format!("attachment; filename=\"{}\"", filename);
 
         let _m = server
-            .mock("GET", "/api/tenants/test-tenant/documents/123/file")
+            .mock("GET", "/api/tenants/test-tenant/files/123/file")
             .with_status(200)
             .with_header("content-disposition", &content_disposition)
             .with_body(file_content)
@@ -61,7 +61,7 @@ mod tests {
         let content_disposition = format!("attachment; filename=\"{}\"", filename);
 
         let _m = server
-            .mock("GET", "/api/tenants/test-tenant/documents/123/file")
+            .mock("GET", "/api/tenants/test-tenant/files/123/file")
             .with_status(200)
             .with_header("content-disposition", &content_disposition)
             .with_body(file_content)

--- a/src/tests/api/manage_inject.rs
+++ b/src/tests/api/manage_inject.rs
@@ -3,7 +3,7 @@ mod tests {
     use crate::process::exec_utils::decode_filename;
     use mockito;
     use std::fs::create_dir_all;
-    use std::io::Read;
+    use std::io::{Read, Write};
     use std::{env, fs};
 
     #[test]
@@ -98,6 +98,78 @@ mod tests {
         let mut file = fs::File::open(&expected_file_path).unwrap();
         file.read_to_string(&mut content).unwrap();
         assert_eq!(content, file_content);
+
+        // -- CLEAN --
+        fs::remove_file(expected_file_path).unwrap();
+    }
+
+    #[test]
+    fn test_download_encrypted_sample_to_disk_success() {
+        // Resolve the payloads path and create it on the fly
+        let current_exe_path = env::current_exe().unwrap();
+        let parent_path = current_exe_path.parent().unwrap();
+        let folder_name = parent_path.file_name().unwrap().to_str().unwrap();
+        let payloads_path = parent_path
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("payloads")
+            .join(folder_name);
+        create_dir_all(&payloads_path).expect("Cannot create payloads directory");
+
+        // Build a password-protected (AES-256) zip holding a single sample entry, in memory,
+        // mirroring what the OpenAEV Files feature serves for an encrypted malware sample.
+        let sample_name = "decrypted-sample.txt";
+        let sample_content = "Hello, encrypted OpenAEV!";
+        let password = "s3cr3t-p4ss";
+        let mut zip_buffer = std::io::Cursor::new(Vec::new());
+        {
+            let mut zip = zip::ZipWriter::new(&mut zip_buffer);
+            let options = zip::write::SimpleFileOptions::default()
+                .compression_method(zip::CompressionMethod::Deflated)
+                .with_aes_encryption(zip::AesMode::Aes256, password);
+            zip.start_file(sample_name, options).unwrap();
+            zip.write_all(sample_content.as_bytes()).unwrap();
+            zip.finish().unwrap();
+        }
+        let zip_bytes = zip_buffer.into_inner();
+
+        let mut server = mockito::Server::new();
+        let server_url = server.url();
+
+        let _m = server
+            .mock("GET", "/api/tenants/test-tenant/files/123/file")
+            .with_status(200)
+            .with_body(zip_bytes)
+            .create();
+
+        let client = crate::api::Client::new(
+            server_url,
+            crate::tests::api::client::TOKEN_TEST.to_string(),
+            false,
+            false,
+        );
+
+        // -- EXECUTE --
+        let result = client.download_file_maybe_encrypted(
+            &"123".to_string(),
+            "test-tenant".to_string(),
+            false,
+            &Some(password.to_string()),
+        );
+
+        // -- ASSERT --
+        assert!(result.is_ok());
+        assert_eq!(result.as_ref().unwrap(), sample_name);
+
+        let expected_file_path = payloads_path.join(sample_name);
+        assert!(expected_file_path.exists());
+
+        let mut content = String::new();
+        let mut file = fs::File::open(&expected_file_path).unwrap();
+        file.read_to_string(&mut content).unwrap();
+        assert_eq!(content, sample_content);
 
         // -- CLEAN --
         fs::remove_file(expected_file_path).unwrap();


### PR DESCRIPTION
Adds on-the-fly decryption of encrypted malware samples for the OpenAEV Files feature.

- File download path moved from `/documents` to `/files`.
- New `zip` crate (aes-crypto) and a `payload_sample_zip_password` field on the payload.
- When the payload marks the file as an encrypted sample, the response is buffered, the password-protected zip is decrypted in memory, and the single contained entry is written to the payloads directory just before file drop/execute.
- The decrypt path rejects any archive that does not contain exactly one file entry (and rejects a directory entry) before extracting, so a malformed or multi-entry sample can never be detonated silently.
- `Cargo.lock` is regenerated so the new `zip` dependency is recorded, and the branch is rebased on `main` to clear the lockfile conflict.

Pairs with OpenAEV-Platform/openaev#6842.

Closes #163

## Test plan
- [x] `cargo build && cargo test` - 26 tests passing, including a new AES-256 encrypted-sample decrypt-to-disk test.
- [ ] End-to-end: run an inject with a FileDrop/Executable sample and confirm decrypt + detonation.

## Follow-up (out of scope)
- `handle_file` unconditionally calls `delete_file(&filename)` before returning the filename; for the Executable flow this removes the payload before `handle_execution_file` runs it. This is pre-existing behavior on `main` (unchanged by this PR) and should be addressed in a dedicated change.
