### PR TITLE
fix(deps): update rust crate h2 to 0.4.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
     "atomic-waker",
     "bytes",


### PR DESCRIPTION
Unblocks `main`: `cargo audit` fails in the *Quality gates* job since RUSTSEC-2026-0258 was published on 2026-08-17.

```
Crate:    h2  0.4.15
Title:    h2 unbounded empty DATA frames
ID:       RUSTSEC-2026-0258
Solution: Upgrade to >=0.4.16
```

`h2` is a transitive dependency, so this is a lockfile-only bump (2 lines). The `Cargo.toml` of h2 0.4.16 differs from 0.4.15 by the version number alone — no dependency requirement changed — so no other lock entry moves.

**Overlaps with #175** — that lock-file-maintenance PR now carries the same h2 0.4.16 bump after its rebase and is green, but it is held by `renovate/stability-days`. This PR is the narrow, mergeable-now alternative; close whichever is redundant.

Ref: https://rustsec.org/advisories/RUSTSEC-2026-0258